### PR TITLE
Update fish names and aliases

### DIFF
--- a/app/src/data/fish-list.ts
+++ b/app/src/data/fish-list.ts
@@ -50,8 +50,8 @@ export const fishList: FishEntry[] = [
   },
   {
     id: "makouyu",
-    name_cn: "大口鲌",
-    alias: ["马口鱼"],
+    name_cn: "马口鱼",
+    alias: ["大口扒"],
     name_lat: "Opsariichthys bidens",
     family: "鲤科",
     length: "20cm",
@@ -86,7 +86,7 @@ export const fishList: FishEntry[] = [
   },
   {
     id: "ganzui",
-    name_cn: "翘嘴红鲌",
+    name_cn: "翘嘴",
     alias: ["红鳍鲌"],
     name_lat: "Chanosichthys sp.",
     family: "鲌亚科",


### PR DESCRIPTION
## Summary
- rename the fourth encyclopedia entry to “马口鱼” and update its alias to “大口扒”
- rename the seventh encyclopedia entry display name to “翘嘴” while keeping its existing metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d294389ca88333b149ec04ed0f44e6