### PR TITLE
Show recognition results in modal

### DIFF
--- a/app/src/components/identify/RecognitionSummary.tsx
+++ b/app/src/components/identify/RecognitionSummary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { findFishByName } from "@/lib/fish-utils";
 import { useFishStore } from "@/store/useFishStore";
 import { ConfettiCelebration } from "@/components/identify/ConfettiCelebration";
@@ -24,10 +24,18 @@ export function RecognitionSummary({ result }: Props) {
   const unlockFish = useFishStore((state) => state.unlockFish);
   const collectedFishIds = useFishStore((state) => state.collectedFishIds);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [justUnlocked, setJustUnlocked] = useState(false);
+  const collectedFishIdsRef = useRef(collectedFishIds);
+
+  useEffect(() => {
+    collectedFishIdsRef.current = collectedFishIds;
+  }, [collectedFishIds]);
 
   useEffect(() => {
     if (!result || result.status !== "ok" || !result.name_cn) {
       setCurrentRecognition(null);
+      setJustUnlocked(false);
       return;
     }
 
@@ -43,8 +51,18 @@ export function RecognitionSummary({ result }: Props) {
 
     setCurrentRecognition(payload);
 
-    if (match && (result.confidence ?? 0) >= UNLOCK_THRESHOLD) {
-      unlockFish(match.id);
+    if (match) {
+      const shouldUnlock = (result.confidence ?? 0) >= UNLOCK_THRESHOLD;
+      const alreadyUnlocked = collectedFishIdsRef.current.includes(match.id);
+
+      if (shouldUnlock && !alreadyUnlocked) {
+        unlockFish(match.id);
+        setJustUnlocked(true);
+      } else {
+        setJustUnlocked(false);
+      }
+    } else {
+      setJustUnlocked(false);
     }
   }, [result, setCurrentRecognition, unlockFish]);
 
@@ -53,29 +71,60 @@ export function RecognitionSummary({ result }: Props) {
     return findFishByName(result.name_cn);
   }, [result]);
 
-  const alreadyCollected = match ? collectedFishIds.includes(match.id) : false;
-
   useEffect(() => {
     if (!result) {
       setShowCelebration(false);
       return;
     }
-    if (match && result.status === "ok" && (result.confidence ?? 0) >= UNLOCK_THRESHOLD && !alreadyCollected) {
-      setShowCelebration(true);
-    }
-  }, [result, match, alreadyCollected]);
 
-  if (!result) {
+    if (justUnlocked) {
+      setShowCelebration(true);
+    } else {
+      setShowCelebration(false);
+    }
+  }, [result, justUnlocked]);
+
+  useEffect(() => {
+    if (!result) {
+      setShowCelebration(false);
+      setIsOpen(false);
+      return;
+    }
+    setIsOpen(true);
+  }, [result]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setShowCelebration(false);
+  };
+
+  if (!result || !isOpen) {
     return null;
   }
 
   if (result.status !== "ok") {
     return (
-      <div className="rounded-3xl border border-orange-200 bg-orange-50 p-6 text-sm text-orange-700">
-        <h2 className="text-base font-semibold">识别失败</h2>
-        <p className="mt-2">
-          {result.reason || "未能识别鱼种，请尝试上传更清晰的正面照片。"}
-        </p>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <button
+          type="button"
+          onClick={handleClose}
+          className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+          aria-label="关闭识别结果"
+        />
+        <div className="relative z-10 w-full max-w-md space-y-4 rounded-3xl border border-orange-200 bg-orange-50 p-6 text-sm text-orange-700 shadow-xl">
+          <div className="flex items-start justify-between gap-4">
+            <h2 className="text-base font-semibold">识别失败</h2>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="rounded-full p-1 text-orange-500 transition hover:bg-orange-100"
+              aria-label="关闭"
+            >
+              ×
+            </button>
+          </div>
+          <p>{result.reason || "未能识别鱼种，请尝试上传更清晰的正面照片。"}</p>
+        </div>
       </div>
     );
   }
@@ -83,31 +132,50 @@ export function RecognitionSummary({ result }: Props) {
   const unlocked = match && (result.confidence ?? 0) >= UNLOCK_THRESHOLD;
 
   return (
-    <div className="space-y-4 rounded-3xl border border-sky-200 bg-white p-6 shadow-sm">
-      {showCelebration && (
-        <ConfettiCelebration onComplete={() => setShowCelebration(false)} />
-      )}
-      <div className="flex flex-col gap-1">
-        <span className="text-xs font-semibold text-sky-500">识别结果</span>
-        <h2 className="text-2xl font-semibold text-slate-900">{result.name_cn}</h2>
-      </div>
-      <div className="grid gap-3 text-sm text-slate-600">
-        <p>拉丁学名：{result.name_lat || "暂缺"}</p>
-        <p>所属科目：{result.family || "暂缺"}</p>
-        <p>{result.description || "暂无更多描述。"}</p>
-      </div>
-      {match ? (
-        unlocked ? (
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
-            <h3 className="font-semibold">成功解锁：{match.name_cn}</h3>
-            <p className="mt-1">已同步至图鉴，快去查看详细插画与资料吧！</p>
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <button
+        type="button"
+        onClick={handleClose}
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
+        aria-label="关闭识别结果"
+      />
+      <div className="relative z-10 w-full max-w-md space-y-5 rounded-3xl border border-sky-200 bg-white p-6 shadow-xl">
+        {showCelebration && (
+          <ConfettiCelebration onComplete={() => setShowCelebration(false)} />
+        )}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-slate-900">{result.name_cn}</h2>
+            <div className="grid gap-1 text-xs text-slate-500">
+              <span>拉丁学名：{result.name_lat || "暂缺"}</span>
+              <span>所属科目：{result.family || "暂缺"}</span>
+            </div>
           </div>
-        ) : (
-          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-xs text-amber-600">
-            置信度偏低，已保留识别信息但暂未解锁。可尝试拍摄更清晰的照片。
-          </div>
-        )
-      ) : null}
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full p-1 text-slate-500 transition hover:bg-slate-100"
+            aria-label="关闭"
+          >
+            ×
+          </button>
+        </div>
+        <p className="text-sm text-slate-600">{result.description || "暂无更多描述。"}</p>
+        {match ? (
+          unlocked ? (
+            justUnlocked ? (
+              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+                <h3 className="font-semibold">成功解锁：{match.name_cn}</h3>
+                <p className="mt-1">已同步至图鉴，快去查看详细插画与资料吧！</p>
+              </div>
+            ) : null
+          ) : (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-xs text-amber-600">
+              置信度偏低，已保留识别信息但暂未解锁。可尝试拍摄更清晰的照片。
+            </div>
+          )
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- present recognition feedback inside a full-screen modal overlay and add close controls
- adjust recognition effects to track newly unlocked fish and avoid re-showing unlock text for previously collected entries
- hide the “识别结果” label while keeping existing fish details in the modal

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2b6b695648333b62a6a33811a6c53