### PR TITLE
Revamp identify celebration and navigation polish

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -37,24 +37,31 @@ a {
 
 .confetti-piece {
   position: absolute;
-  top: -12vh;
+  bottom: clamp(80px, 16vh, 180px);
+  left: 50%;
   border-radius: 9999px;
   opacity: 0;
-  animation-name: confetti-fall;
-  animation-timing-function: linear;
+  transform: translate3d(calc(-50% + var(--confetti-start, 0px)), 0, 0) scale(0.8);
+  animation-name: confetti-rise;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   animation-fill-mode: forwards;
 }
 
-@keyframes confetti-fall {
+@keyframes confetti-rise {
   0% {
-    transform: translate3d(0, -120vh, 0) rotate(0deg);
+    transform: translate3d(calc(-50% + var(--confetti-start, 0px)), 16px, 0) scale(0.65) rotate(0deg);
     opacity: 0;
   }
-  10% {
+  18% {
     opacity: 1;
   }
   100% {
-    transform: translate3d(var(--confetti-x, 0px), 120vh, 0) rotate(540deg);
+    transform: translate3d(
+        calc(-50% + var(--confetti-x, 0px)),
+        var(--confetti-y, -60vh),
+        0
+      )
+      rotate(var(--confetti-rotate, 540deg));
     opacity: 0;
   }
 }

--- a/app/src/app/identify/page.tsx
+++ b/app/src/app/identify/page.tsx
@@ -99,6 +99,12 @@ export default function IdentifyPage() {
     }
   };
 
+  const tips = [
+    "保持光线充足并尽量正面拍摄，让整条鱼清晰可见。",
+    "避免背景杂乱或多条鱼同框，识别会更准确。",
+    "识别成功后会自动同步至我的图鉴收藏。",
+  ];
+
   return (
     <section className="flex flex-1 flex-col gap-5 pb-4">
       <header className="space-y-2">
@@ -170,6 +176,17 @@ export default function IdentifyPage() {
         >
           {isLoading ? "正在识别..." : "开始识别"}
         </button>
+
+        <div className="grid gap-3 rounded-2xl border border-sky-100 bg-sky-50/60 p-4 text-xs text-sky-700 sm:grid-cols-3">
+          {tips.map((tip, index) => (
+            <div key={tip} className="flex items-start gap-2">
+              <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/80 text-[11px] font-semibold text-sky-600 shadow-sm">
+                {index + 1}
+              </span>
+              <p className="leading-relaxed">{tip}</p>
+            </div>
+          ))}
+        </div>
 
         {error && (
           <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">

--- a/app/src/components/identify/ConfettiCelebration.tsx
+++ b/app/src/components/identify/ConfettiCelebration.tsx
@@ -4,28 +4,181 @@ import { useEffect } from "react";
 import type { CSSProperties } from "react";
 
 const CONFETTI_PRESET = [
-  { id: 1, left: "5%", delay: 0, duration: 2.4, color: "#38bdf8", offset: "-30px", width: 8, height: 16 },
-  { id: 2, left: "15%", delay: 0.1, duration: 2.6, color: "#f97316", offset: "20px", width: 10, height: 18 },
-  { id: 3, left: "25%", delay: 0.2, duration: 2.5, color: "#a855f7", offset: "-10px", width: 7, height: 14 },
-  { id: 4, left: "35%", delay: 0.05, duration: 2.8, color: "#22c55e", offset: "30px", width: 9, height: 16 },
-  { id: 5, left: "45%", delay: 0.15, duration: 2.7, color: "#facc15", offset: "-25px", width: 8, height: 18 },
-  { id: 6, left: "55%", delay: 0.05, duration: 2.9, color: "#38bdf8", offset: "35px", width: 10, height: 17 },
-  { id: 7, left: "65%", delay: 0.25, duration: 2.5, color: "#f97316", offset: "-20px", width: 9, height: 16 },
-  { id: 8, left: "75%", delay: 0.1, duration: 2.6, color: "#a855f7", offset: "28px", width: 8, height: 15 },
-  { id: 9, left: "85%", delay: 0.18, duration: 2.8, color: "#22c55e", offset: "-18px", width: 9, height: 17 },
-  { id: 10, left: "12%", delay: 0.32, duration: 2.7, color: "#facc15", offset: "24px", width: 7, height: 15 },
-  { id: 11, left: "32%", delay: 0.27, duration: 2.5, color: "#38bdf8", offset: "-22px", width: 8, height: 14 },
-  { id: 12, left: "52%", delay: 0.35, duration: 2.9, color: "#f97316", offset: "18px", width: 9, height: 16 },
-  { id: 13, left: "72%", delay: 0.22, duration: 2.6, color: "#a855f7", offset: "-28px", width: 8, height: 18 },
-  { id: 14, left: "92%", delay: 0.3, duration: 2.7, color: "#22c55e", offset: "16px", width: 10, height: 17 },
-  { id: 15, left: "2%", delay: 0.26, duration: 2.8, color: "#facc15", offset: "-15px", width: 9, height: 15 },
-  { id: 16, left: "48%", delay: 0.4, duration: 3, color: "#38bdf8", offset: "32px", width: 11, height: 18 },
-  { id: 17, left: "68%", delay: 0.36, duration: 2.9, color: "#f97316", offset: "-26px", width: 9, height: 16 },
-  { id: 18, left: "88%", delay: 0.42, duration: 2.8, color: "#a855f7", offset: "22px", width: 8, height: 14 }
+  {
+    id: 1,
+    start: "-48px",
+    x: "-168px",
+    y: "-64vh",
+    rotate: "640deg",
+    delay: 0,
+    duration: 2.6,
+    color: "#38bdf8",
+    width: 9,
+    height: 18,
+  },
+  {
+    id: 2,
+    start: "-36px",
+    x: "-138px",
+    y: "-60vh",
+    rotate: "600deg",
+    delay: 0.08,
+    duration: 2.7,
+    color: "#f97316",
+    width: 8,
+    height: 16,
+  },
+  {
+    id: 3,
+    start: "-28px",
+    x: "-112px",
+    y: "-56vh",
+    rotate: "690deg",
+    delay: 0.15,
+    duration: 2.5,
+    color: "#a855f7",
+    width: 7,
+    height: 15,
+  },
+  {
+    id: 4,
+    start: "-16px",
+    x: "-86px",
+    y: "-58vh",
+    rotate: "620deg",
+    delay: 0.05,
+    duration: 2.8,
+    color: "#22c55e",
+    width: 9,
+    height: 16,
+  },
+  {
+    id: 5,
+    start: "-6px",
+    x: "-62px",
+    y: "-62vh",
+    rotate: "720deg",
+    delay: 0.12,
+    duration: 2.9,
+    color: "#facc15",
+    width: 8,
+    height: 18,
+  },
+  {
+    id: 6,
+    start: "4px",
+    x: "-34px",
+    y: "-65vh",
+    rotate: "670deg",
+    delay: 0.04,
+    duration: 2.85,
+    color: "#38bdf8",
+    width: 8,
+    height: 17,
+  },
+  {
+    id: 7,
+    start: "12px",
+    x: "-6px",
+    y: "-68vh",
+    rotate: "760deg",
+    delay: 0.18,
+    duration: 3,
+    color: "#38bdf8",
+    width: 9,
+    height: 19,
+  },
+  {
+    id: 8,
+    start: "22px",
+    x: "24px",
+    y: "-64vh",
+    rotate: "650deg",
+    delay: 0.1,
+    duration: 2.7,
+    color: "#f97316",
+    width: 8,
+    height: 16,
+  },
+  {
+    id: 9,
+    start: "32px",
+    x: "52px",
+    y: "-60vh",
+    rotate: "700deg",
+    delay: 0.2,
+    duration: 2.6,
+    color: "#a855f7",
+    width: 9,
+    height: 18,
+  },
+  {
+    id: 10,
+    start: "42px",
+    x: "82px",
+    y: "-58vh",
+    rotate: "640deg",
+    delay: 0.06,
+    duration: 2.9,
+    color: "#22c55e",
+    width: 8,
+    height: 16,
+  },
+  {
+    id: 11,
+    start: "54px",
+    x: "112px",
+    y: "-60vh",
+    rotate: "710deg",
+    delay: 0.24,
+    duration: 2.75,
+    color: "#facc15",
+    width: 7,
+    height: 14,
+  },
+  {
+    id: 12,
+    start: "64px",
+    x: "138px",
+    y: "-62vh",
+    rotate: "660deg",
+    delay: 0.16,
+    duration: 2.9,
+    color: "#38bdf8",
+    width: 9,
+    height: 18,
+  },
+  {
+    id: 13,
+    start: "74px",
+    x: "164px",
+    y: "-65vh",
+    rotate: "720deg",
+    delay: 0.3,
+    duration: 3.05,
+    color: "#f97316",
+    width: 8,
+    height: 17,
+  },
+  {
+    id: 14,
+    start: "-58px",
+    x: "-152px",
+    y: "-66vh",
+    rotate: "700deg",
+    delay: 0.28,
+    duration: 3,
+    color: "#a855f7",
+    width: 9,
+    height: 17,
+  },
 ] as const;
 
 type ConfettiStyle = CSSProperties & {
+  "--confetti-start"?: string;
   "--confetti-x"?: string;
+  "--confetti-y"?: string;
+  "--confetti-rotate"?: string;
 };
 
 type Props = {
@@ -33,7 +186,7 @@ type Props = {
   onComplete?: () => void;
 };
 
-export function ConfettiCelebration({ duration = 2600, onComplete }: Props) {
+export function ConfettiCelebration({ duration = 3200, onComplete }: Props) {
   useEffect(() => {
     if (!onComplete) return;
     const timer = window.setTimeout(() => {
@@ -46,13 +199,15 @@ export function ConfettiCelebration({ duration = 2600, onComplete }: Props) {
     <div className="confetti-container">
       {CONFETTI_PRESET.map((piece) => {
         const style: ConfettiStyle = {
-          left: piece.left,
           backgroundColor: piece.color,
           animationDelay: `${piece.delay}s`,
           animationDuration: `${piece.duration}s`,
           width: piece.width,
           height: piece.height,
-          "--confetti-x": piece.offset,
+          "--confetti-start": piece.start,
+          "--confetti-x": piece.x,
+          "--confetti-y": piece.y,
+          "--confetti-rotate": piece.rotate,
         };
         return <span key={piece.id} className="confetti-piece" style={style} />;
       })}

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -40,10 +40,10 @@ export function AppShell({ children }: { children: ReactNode }) {
                   key={item.href}
                   href={item.href}
                   className={cn(
-                    "rounded-full px-3 py-1.5 transition",
+                    "rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200",
                     active
-                      ? "bg-sky-100 text-sky-700"
-                      : "text-slate-500 hover:bg-sky-100 hover:text-sky-700"
+                      ? "bg-gradient-to-r from-sky-500/10 via-sky-500/20 to-sky-500/10 text-sky-700 shadow-[0_12px_30px_-22px_rgba(14,165,233,0.8)] scale-[1.04]"
+                      : "text-slate-500 hover:bg-sky-500/10 hover:text-sky-700 hover:shadow-[0_10px_26px_-24px_rgba(14,165,233,0.85)] hover:scale-[1.03]"
                   )}
                   aria-current={active ? "page" : undefined}
                 >

--- a/app/src/components/navigation/BottomNav.tsx
+++ b/app/src/components/navigation/BottomNav.tsx
@@ -23,18 +23,25 @@ export function BottomNav() {
               <Link
                 href={item.href}
                 className={cn(
-                  "flex flex-col items-center gap-1 rounded-xl px-4 py-2 text-sm",
+                  "group flex flex-col items-center gap-1 rounded-2xl px-4 py-2 text-xs font-medium transition-all duration-200",
                   active
-                    ? "text-sky-600"
-                    : "text-neutral-500 hover:text-neutral-700"
+                    ? "bg-white/90 text-sky-600 shadow-[0_12px_28px_-20px_rgba(2,132,199,0.9)] backdrop-blur"
+                    : "text-neutral-500 hover:bg-sky-50/80 hover:text-sky-600"
                 )}
                 aria-current={active ? "page" : undefined}
               >
-                <span className="text-base">{item.label}</span>
                 <span
                   className={cn(
-                    "h-0.5 w-6 rounded-full transition-opacity",
-                    active ? "bg-sky-600 opacity-100" : "opacity-0"
+                    "text-base transition-transform duration-200",
+                    active ? "scale-[1.05]" : "group-hover:scale-105"
+                  )}
+                >
+                  {item.label}
+                </span>
+                <span
+                  className={cn(
+                    "h-1 w-8 origin-center rounded-full bg-gradient-to-r from-sky-400 via-sky-500 to-sky-400 transition-all duration-200",
+                    active ? "scale-100 opacity-100" : "scale-0 opacity-0"
                   )}
                 />
               </Link>


### PR DESCRIPTION
## Summary
- replace the recognition unlock celebration with an upward fan confetti animation and longer runtime
- add three helpful recognition tips beneath the image capture area on the identify page
- smooth out the identify/encyclopedia navigation highlighting for desktop and mobile menus

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2be557f4c83338fdbcb98d8e42aec