### PR TITLE
Adjust identify workflow layout

### DIFF
--- a/app/src/app/identify/page.tsx
+++ b/app/src/app/identify/page.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import { FormEvent, useRef, useState } from "react";
 import { RecognitionSummary } from "@/components/identify/RecognitionSummary";
-import { CameraIcon, PhotoIcon } from "@/components/ui/IconSet";
+import { CameraIcon } from "@/components/ui/IconSet";
 
 type RecognitionResponse = {
   status: string;
@@ -17,7 +17,6 @@ type RecognitionResponse = {
 
 export default function IdentifyPage() {
   const cameraInputRef = useRef<HTMLInputElement | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [mimeType, setMimeType] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -50,15 +49,11 @@ export default function IdentifyPage() {
     cameraInputRef.current?.click();
   };
 
-  const handleOpenFilePicker = () => {
-    fileInputRef.current?.click();
-  };
-
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!preview || !mimeType) {
-      setError("请先拍照或上传图片。");
+      setError("请先拍摄照片或选择图片。");
       return;
     }
     try {
@@ -68,7 +63,7 @@ export default function IdentifyPage() {
 
       const base64 = preview.split(",")[1];
       if (!base64) {
-        setError("图片数据无效，请重新上传。");
+        setError("图片数据无效，请重新拍摄或选择。");
         setIsLoading(false);
         return;
       }
@@ -106,7 +101,7 @@ export default function IdentifyPage() {
       <header className="space-y-2">
         <h1 className="text-2xl font-semibold">鱼类识别</h1>
         <p className="text-xs text-slate-500">
-          拍照或上传清晰图片，智能识别鱼类并同步解锁我的专属图鉴。
+          拍摄清晰图片，智能识别鱼类并同步解锁我的专属图鉴。
         </p>
       </header>
       <form
@@ -115,7 +110,7 @@ export default function IdentifyPage() {
         noValidate
       >
         <fieldset className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-sky-200 bg-sky-50/60 px-4 py-6 text-center">
-          <legend className="sr-only">上传或拍摄鱼类照片</legend>
+          <legend className="sr-only">拍摄鱼类照片</legend>
           {preview ? (
             <div className="relative h-48 w-full overflow-hidden rounded-2xl">
               <Image
@@ -133,7 +128,7 @@ export default function IdentifyPage() {
             </div>
           )}
           {!preview && (
-            <p className="text-sm text-sky-600/80">轻点按钮拍摄或上传</p>
+            <p className="text-sm text-sky-600/80">轻点按钮拍摄</p>
           )}
           <div className="flex w-full flex-col gap-3 sm:flex-row">
             <button
@@ -144,27 +139,12 @@ export default function IdentifyPage() {
               <CameraIcon className="h-4 w-4" />
               拍照识别
             </button>
-            <button
-              onClick={handleOpenFilePicker}
-              className="flex flex-1 items-center justify-center gap-2 rounded-full border border-sky-200 px-5 py-3 text-sm font-medium text-sky-600 transition active:scale-[0.98] sm:text-base"
-              type="button"
-            >
-              <PhotoIcon className="h-4 w-4" />
-              上传图片
-            </button>
           </div>
           <input
             ref={cameraInputRef}
             type="file"
             accept="image/*"
             capture="environment"
-            className="hidden"
-            onChange={(event) => handleFileSelect(event.target.files?.[0] ?? null)}
-          />
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
             className="hidden"
             onChange={(event) => handleFileSelect(event.target.files?.[0] ?? null)}
           />

--- a/app/src/components/identify/RecognitionSummary.tsx
+++ b/app/src/components/identify/RecognitionSummary.tsx
@@ -24,7 +24,6 @@ export function RecognitionSummary({ result }: Props) {
   const unlockFish = useFishStore((state) => state.unlockFish);
   const collectedFishIds = useFishStore((state) => state.collectedFishIds);
   const [showCelebration, setShowCelebration] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
   const [justUnlocked, setJustUnlocked] = useState(false);
   const collectedFishIdsRef = useRef(collectedFishIds);
 
@@ -84,47 +83,15 @@ export function RecognitionSummary({ result }: Props) {
     }
   }, [result, justUnlocked]);
 
-  useEffect(() => {
-    if (!result) {
-      setShowCelebration(false);
-      setIsOpen(false);
-      return;
-    }
-    setIsOpen(true);
-  }, [result]);
-
-  const handleClose = () => {
-    setIsOpen(false);
-    setShowCelebration(false);
-  };
-
-  if (!result || !isOpen) {
+  if (!result) {
     return null;
   }
 
   if (result.status !== "ok") {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center">
-        <button
-          type="button"
-          onClick={handleClose}
-          className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
-          aria-label="关闭识别结果"
-        />
-        <div className="relative z-10 w-full max-w-md space-y-4 rounded-3xl border border-orange-200 bg-orange-50 p-6 text-sm text-orange-700 shadow-xl">
-          <div className="flex items-start justify-between gap-4">
-            <h2 className="text-base font-semibold">识别失败</h2>
-            <button
-              type="button"
-              onClick={handleClose}
-              className="rounded-full p-1 text-orange-500 transition hover:bg-orange-100"
-              aria-label="关闭"
-            >
-              ×
-            </button>
-          </div>
-          <p>{result.reason || "未能识别鱼种，请尝试上传更清晰的正面照片。"}</p>
-        </div>
+      <div className="space-y-2 rounded-3xl border border-orange-200 bg-orange-50 p-6 text-sm text-orange-700">
+        <h2 className="text-base font-semibold text-orange-600">识别失败</h2>
+        <p>{result.reason || "未能识别鱼种，请尝试拍摄更清晰的正面照片。"}</p>
       </div>
     );
   }
@@ -132,50 +99,32 @@ export function RecognitionSummary({ result }: Props) {
   const unlocked = match && (result.confidence ?? 0) >= UNLOCK_THRESHOLD;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <button
-        type="button"
-        onClick={handleClose}
-        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm"
-        aria-label="关闭识别结果"
-      />
-      <div className="relative z-10 w-full max-w-md space-y-5 rounded-3xl border border-sky-200 bg-white p-6 shadow-xl">
-        {showCelebration && (
-          <ConfettiCelebration onComplete={() => setShowCelebration(false)} />
-        )}
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h2 className="text-2xl font-semibold text-slate-900">{result.name_cn}</h2>
-            <div className="grid gap-1 text-xs text-slate-500">
-              <span>拉丁学名：{result.name_lat || "暂缺"}</span>
-              <span>所属科目：{result.family || "暂缺"}</span>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="rounded-full p-1 text-slate-500 transition hover:bg-slate-100"
-            aria-label="关闭"
-          >
-            ×
-          </button>
+    <div className="relative space-y-5 rounded-3xl border border-sky-200 bg-white p-6 shadow-sm">
+      {showCelebration && (
+        <ConfettiCelebration onComplete={() => setShowCelebration(false)} />
+      )}
+      <div className="space-y-1">
+        <h2 className="text-2xl font-semibold text-slate-900">{result.name_cn}</h2>
+        <div className="grid gap-1 text-xs text-slate-500">
+          <span>拉丁学名：{result.name_lat || "暂缺"}</span>
+          <span>所属科目：{result.family || "暂缺"}</span>
         </div>
-        <p className="text-sm text-slate-600">{result.description || "暂无更多描述。"}</p>
-        {match ? (
-          unlocked ? (
-            justUnlocked ? (
-              <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
-                <h3 className="font-semibold">成功解锁：{match.name_cn}</h3>
-                <p className="mt-1">已同步至图鉴，快去查看详细插画与资料吧！</p>
-              </div>
-            ) : null
-          ) : (
-            <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-xs text-amber-600">
-              置信度偏低，已保留识别信息但暂未解锁。可尝试拍摄更清晰的照片。
-            </div>
-          )
-        ) : null}
       </div>
+      <p className="text-sm text-slate-600">{result.description || "暂无更多描述。"}</p>
+      {match ? (
+        unlocked ? (
+          justUnlocked ? (
+            <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+              <h3 className="font-semibold">成功解锁：{match.name_cn}</h3>
+              <p className="mt-1">已同步至图鉴，快去查看详细插画与资料吧！</p>
+            </div>
+          ) : null
+        ) : (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-xs text-amber-600">
+            置信度偏低，已保留识别信息但暂未解锁。可尝试拍摄更清晰的照片。
+          </div>
+        )
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide the standalone image upload entry on the identify page and update the accompanying copy
- render recognition results as an inline summary card instead of a blocking modal overlay

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2c6911f38833389fbddfff193f98f