### PR TITLE
Rename app to 鳟鱼季

### DIFF
--- a/app/src/app/identify/page.tsx
+++ b/app/src/app/identify/page.tsx
@@ -139,7 +139,7 @@ export default function IdentifyPage() {
   return (
     <section className="flex flex-1 flex-col gap-6 pb-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">鱼眼</h1>
+        <h1 className="text-2xl font-semibold">鳟鱼季</h1>
         <p className="text-xs text-slate-500">
           拍摄清晰图片，智能识别鱼类并同步解锁我的专属图鉴。
         </p>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -9,7 +9,7 @@ const notoSans = Noto_Sans_SC({
 });
 
 export const metadata: Metadata = {
-  title: "鱼眼",
+  title: "鳟鱼季",
   description: "拍照识鱼、解锁专属图鉴进度的移动端应用",
   icons: {
     icon: [

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -26,7 +26,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       <main className="relative z-10 mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pb-24 pt-5 sm:px-6">
         <header className="mb-5 hidden items-center justify-between rounded-2xl border border-white/60 bg-white/80 px-5 py-3 shadow-sm backdrop-blur-md md:flex">
           <Link href="/identify" className="text-base font-semibold text-sky-600">
-            鱼眼
+            鳟鱼季
           </Link>
           <nav className="flex items-center gap-3 text-xs text-slate-500">
             {navItems.map((item) => {

--- a/app/src/components/navigation/navItems.tsx
+++ b/app/src/components/navigation/navItems.tsx
@@ -5,5 +5,5 @@ export type AppNavItem = {
 
 export const navItems: AppNavItem[] = [
   { href: "/encyclopedia", label: "图鉴" },
-  { href: "/identify", label: "鱼眼" },
+  { href: "/identify", label: "鳟鱼季" },
 ];


### PR DESCRIPTION
## Summary
- update the global metadata title to use“鳟鱼季”
- rename the identify page heading and navigation label to the new app name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a727a5b08333ab2d230ff31dacda