### PR TITLE
Rename identify page branding to 识鱼

### DIFF
--- a/app/src/app/identify/page.tsx
+++ b/app/src/app/identify/page.tsx
@@ -139,7 +139,7 @@ export default function IdentifyPage() {
   return (
     <section className="flex flex-1 flex-col gap-6 pb-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">鳟鱼季</h1>
+        <h1 className="text-2xl font-semibold">识鱼</h1>
         <p className="text-xs text-slate-500">
           拍摄清晰图片，智能识别鱼类并同步解锁我的专属图鉴。
         </p>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -9,7 +9,7 @@ const notoSans = Noto_Sans_SC({
 });
 
 export const metadata: Metadata = {
-  title: "鳟鱼季",
+  title: "识鱼",
   description: "拍照识鱼、解锁专属图鉴进度的移动端应用",
   icons: {
     icon: [

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -26,7 +26,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       <main className="relative z-10 mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pb-24 pt-5 sm:px-6">
         <header className="mb-5 hidden items-center justify-between rounded-2xl border border-white/60 bg-white/80 px-5 py-3 shadow-sm backdrop-blur-md md:flex">
           <Link href="/identify" className="text-base font-semibold text-sky-600">
-            鳟鱼季
+            识鱼
           </Link>
           <nav className="flex items-center gap-3 text-xs text-slate-500">
             {navItems.map((item) => {

--- a/app/src/components/navigation/navItems.tsx
+++ b/app/src/components/navigation/navItems.tsx
@@ -5,5 +5,5 @@ export type AppNavItem = {
 
 export const navItems: AppNavItem[] = [
   { href: "/encyclopedia", label: "图鉴" },
-  { href: "/identify", label: "鳟鱼季" },
+  { href: "/identify", label: "识鱼" },
 ];


### PR DESCRIPTION
## Summary
- update global metadata title to 识鱼
- rename the identify navigation item and header copy

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d6ae065c588333ae486df8e8cd8ba6