### PR TITLE
Align branding with 鳟鱼季 while keeping 识鱼 menu

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -9,7 +9,8 @@ const notoSans = Noto_Sans_SC({
 });
 
 export const metadata: Metadata = {
-  title: "识鱼",
+  title: "鳟鱼季",
+  applicationName: "鳟鱼季",
   description: "拍照识鱼、解锁专属图鉴进度的移动端应用",
   icons: {
     icon: [

--- a/app/src/components/layout/AppShell.tsx
+++ b/app/src/components/layout/AppShell.tsx
@@ -26,7 +26,7 @@ export function AppShell({ children }: { children: ReactNode }) {
       <main className="relative z-10 mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pb-24 pt-5 sm:px-6">
         <header className="mb-5 hidden items-center justify-between rounded-2xl border border-white/60 bg-white/80 px-5 py-3 shadow-sm backdrop-blur-md md:flex">
           <Link href="/identify" className="text-base font-semibold text-sky-600">
-            识鱼
+            鳟鱼季
           </Link>
           <nav className="flex items-center gap-3 text-xs text-slate-500">
             {navItems.map((item) => {


### PR DESCRIPTION
## Summary
- set the global metadata title and application name to 鳟鱼季
- update the header branding link to display 鳟鱼季 while preserving the 识鱼 menu label

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6afb3f49c83338fb7388facb7a959