### PR TITLE
Fix reverse geocode offset by converting coordinates

### DIFF
--- a/app/src/app/api/location/reverse-geocode/route.ts
+++ b/app/src/app/api/location/reverse-geocode/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { wgs84ToGcj02 } from "@/lib/coordinate";
+
 const AMAP_API_KEY = process.env.AMAP_API_KEY ?? "";
 
 export async function POST(request: Request) {
@@ -25,9 +27,11 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "未配置高德API密钥" }, { status: 500 });
     }
 
+    const converted = wgs84ToGcj02(latitude, longitude);
+
     const params = new URLSearchParams({
       key: apiKey,
-      location: `${longitude},${latitude}`,
+      location: `${converted.longitude},${converted.latitude}`,
       extensions: "all",
       radius: "1000",
       batch: "false",
@@ -71,7 +75,12 @@ export async function POST(request: Request) {
       address: poiName || formattedAddress || "",
       formattedAddress: formattedAddress || "",
       raw: amapResult.regeocode,
-      coords: { latitude, longitude },
+      coords: {
+        latitude,
+        longitude,
+        gcjLatitude: converted.latitude,
+        gcjLongitude: converted.longitude,
+      },
     });
   } catch (error) {
     console.error("逆地理编码接口异常", error);

--- a/app/src/lib/coordinate.ts
+++ b/app/src/lib/coordinate.ts
@@ -1,0 +1,88 @@
+const PI = Math.PI;
+
+function outOfChina(latitude: number, longitude: number): boolean {
+  return (
+    longitude < 72.004 ||
+    longitude > 137.8347 ||
+    latitude < 0.8293 ||
+    latitude > 55.8271
+  );
+}
+
+function transformLat(x: number, y: number): number {
+  let ret =
+    -100.0 +
+    2.0 * x +
+    3.0 * y +
+    0.2 * y * y +
+    0.1 * x * y +
+    0.2 * Math.sqrt(Math.abs(x));
+  ret +=
+    ((20.0 * Math.sin(6.0 * x * PI) +
+      20.0 * Math.sin(2.0 * x * PI)) *
+      2.0) /
+    3.0;
+  ret +=
+    ((20.0 * Math.sin(y * PI) + 40.0 * Math.sin((y / 3.0) * PI)) * 2.0) /
+    3.0;
+  ret +=
+    ((160.0 * Math.sin((y / 12.0) * PI) +
+      320 * Math.sin((y * PI) / 30.0)) *
+      2.0) /
+    3.0;
+  return ret;
+}
+
+function transformLon(x: number, y: number): number {
+  let ret =
+    300.0 +
+    x +
+    2.0 * y +
+    0.1 * x * x +
+    0.1 * x * y +
+    0.1 * Math.sqrt(Math.abs(x));
+  ret +=
+    ((20.0 * Math.sin(6.0 * x * PI) +
+      20.0 * Math.sin(2.0 * x * PI)) *
+      2.0) /
+    3.0;
+  ret +=
+    ((20.0 * Math.sin(x * PI) + 40.0 * Math.sin((x / 3.0) * PI)) * 2.0) /
+    3.0;
+  ret +=
+    ((150.0 * Math.sin((x / 12.0) * PI) +
+      300.0 * Math.sin((x / 30.0) * PI)) *
+      2.0) /
+    3.0;
+  return ret;
+}
+
+export function wgs84ToGcj02(latitude: number, longitude: number): {
+  latitude: number;
+  longitude: number;
+} {
+  if (outOfChina(latitude, longitude)) {
+    return { latitude, longitude };
+  }
+
+  const a = 6378245.0;
+  const ee = 0.00669342162296594323;
+
+  let dLat = transformLat(longitude - 105.0, latitude - 35.0);
+  let dLon = transformLon(longitude - 105.0, latitude - 35.0);
+  const radLat = (latitude / 180.0) * PI;
+  let magic = Math.sin(radLat);
+  magic = 1 - ee * magic * magic;
+  const sqrtMagic = Math.sqrt(magic);
+  dLat =
+    (dLat * 180.0) /
+    (((a * (1 - ee)) / (magic * sqrtMagic)) * PI);
+  dLon =
+    (dLon * 180.0) /
+    ((a / sqrtMagic) * Math.cos(radLat) * PI);
+
+  return {
+    latitude: latitude + dLat,
+    longitude: longitude + dLon,
+  };
+}


### PR DESCRIPTION
## Summary
- add WGS84 to GCJ-02 conversion utility for location normalization
- convert coordinates before calling the AMap reverse geocoding API to reduce marker offset
- include both raw and converted coordinates in the API response for debugging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d738ace4f0833385c9afe358e08b29