### PR TITLE
Fix duplicate registration flow to avoid overwriting existing users

### DIFF
--- a/app/src/app/api/user/profile/route.ts
+++ b/app/src/app/api/user/profile/route.ts
@@ -3,6 +3,7 @@ import {
   createUserProfile,
   verifyPhoneCredentials,
   getUserProfileByPhone,
+  UserProfileAlreadyExistsError,
 } from "@/lib/userProfile";
 import { getCollectedFishIds } from "@/lib/progress";
 
@@ -65,6 +66,9 @@ export async function POST(req: NextRequest) {
       collectedFishIds: [],
     });
   } catch (error) {
+    if (error instanceof UserProfileAlreadyExistsError) {
+      return Response.json({ error: "该手机号已注册，请直接登录" }, { status: 409 });
+    }
     console.error("注册失败", error);
     return Response.json({ error: "注册失败" }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- add an explicit error for duplicate phone numbers when creating user profiles
- return a 409 conflict response during registration if the phone number already exists

## Testing
- npm run lint *(fails: scripts/reset-user-password.js uses require() imports flagged by eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d938d3e25c83338bcf6866c14b479b