### PR TITLE
Remove local cache for encyclopedia unlock and marks data

### DIFF
--- a/app/src/app/encyclopedia/page.tsx
+++ b/app/src/app/encyclopedia/page.tsx
@@ -47,7 +47,9 @@ export default function EncyclopediaPage() {
     if (!userId) return;
     (async () => {
       try {
-        const res = await fetch(`/api/user?userId=${encodeURIComponent(userId)}`);
+        const res = await fetch(`/api/user?userId=${encodeURIComponent(userId)}`, {
+          cache: "no-store",
+        });
         if (res.ok) {
           const data = await res.json();
           if (Array.isArray(data?.collectedFishIds)) {


### PR DESCRIPTION
## Summary
- remove localStorage usage from the collection sync hook and always read unlock progress from the database
- ensure the encyclopedia page reloads unlock status directly from the server without caching
- drop localStorage caching for mark synchronization so location marks rely solely on remote data

## Testing
- npm run lint *(fails: `scripts/reset-user-password.js` uses CommonJS `require` which is forbidden by the ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d9463dff64833388a41fca8c67b009