### PR TITLE
Fix identify carousel targetFishId prop type

### DIFF
--- a/app/src/app/identify/page.tsx
+++ b/app/src/app/identify/page.tsx
@@ -194,9 +194,9 @@ export default function IdentifyPage() {
           }`}
         >
           {showCarousel ? (
-            <FishCarousel 
+            <FishCarousel
               isAnimating={isLoading}
-              targetFishId={targetFishId}
+              targetFishId={targetFishId ?? undefined}
               onAnimationComplete={() => setShowCarousel(false)}
             />
           ) : preview ? (


### PR DESCRIPTION
## Summary
- ensure the identify page passes `undefined` instead of `null` to the FishCarousel `targetFishId`

## Testing
- npm run lint *(fails: existing lint errors in scripts/reset-user-password.js and FishCarousel.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68db546be0f88333b370ed891c7b6e19